### PR TITLE
Enable headless background notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ You've successfully run and modified your React Native App. :partying_face:
 - If you want to add this new React Native code to an existing application, check out the [Integration guide](https://reactnative.dev/docs/integration-with-existing-apps).
 - If you're curious to learn more about React Native, check out the [Introduction to React Native](https://reactnative.dev/docs/getting-started).
 
+## Background notifications
+
+The app periodically checks for pharmacy shifts using `react-native-background-fetch`.
+Even when the application is closed, the service runs in the background and
+schedules notifications whenever a new shift begins.
+
 # Troubleshooting
 
 If you can't get this to work, see the [Troubleshooting](https://reactnative.dev/docs/troubleshooting) page.

--- a/backgroundFetchHeadless.ts
+++ b/backgroundFetchHeadless.ts
@@ -1,0 +1,15 @@
+import BackgroundFetch from 'react-native-background-fetch';
+import { checkAndNotifyTurnos } from './src/services/TurnoService';
+
+// Headless task invoked when the app is terminated.
+const BackgroundFetchHeadlessTask = async (event: any) => {
+  console.log('[BackgroundFetch HeadlessTask] start');
+  try {
+    await checkAndNotifyTurnos();
+  } finally {
+    BackgroundFetch.finish(event.taskId);
+  }
+};
+
+// Register the task at the JS runtime level.
+BackgroundFetch.registerHeadlessTask(BackgroundFetchHeadlessTask);

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import App from './App';
 import {name as appName} from './app.json';
 import notifee, { EventType } from '@notifee/react-native';
 import 'react-native-gesture-handler';
+import './backgroundFetchHeadless';
 
 notifee.onBackgroundEvent(async ({ type, detail }) => {
   const { notification, pressAction } = detail;


### PR DESCRIPTION
## Summary
- register a background fetch headless task
- trigger checkAndNotifyTurnos even when the app is closed
- document background notifications

## Testing
- `yarn test` *(fails: Error when performing the request to https://repo.yarnpkg.com/3.6.4/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_e_684b593fe9208320a8696fa896ede5d3